### PR TITLE
Allow for people to start tracking ~0.0@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 
     "require": {
         "php": ">=5.5",
-        "event-centric/domain-events": "*",
+        "event-centric/domain-events": "~0.0@dev",
         "mathiasverraes/classfunctions": "1.*"
     },
 
@@ -27,5 +27,11 @@
 
     "config": {
         "bin-dir": "bin"
+    },
+
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This won't fix the fact that people may still experience massive BC breaks during development, but at least we will have less people requiring dev-master in the wild. :)

(Tests for this will not likely pass before event-centric/domain-events#1 is merged)
