### PR TITLE
Composer package cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 
     "require": {
         "php": ">=5.5",
-        "event-centric/domain-events": "*",
+        "event-centric/domain-events": "~0.0@dev",
         "mathiasverraes/classfunctions": "1.*"
     },
 
@@ -27,5 +27,11 @@
 
     "config": {
         "bin-dir": "bin"
+    },
+
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.0.x-dev"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "event-centric/when",
     "description": "Delegate Domain Events to event-specific methods",
-    "minimum-stability": "dev",
     "license": "MIT",
     "homepage": "https://github.com/event-centric/when",
     "authors": [
@@ -21,12 +20,14 @@
 
     "autoload": {
         "psr-4": {
-            "EventCentric\\When\\": ["src/EventCentric/When", "tests/EventCentric/When"]
+            "EventCentric\\When\\": ["src/EventCentric/When"]
         }
     },
 
-    "config": {
-        "bin-dir": "bin"
+    "autoload-dev": {
+        "psr-4": {
+            "EventCentric\\When\\": ["tests/EventCentric/When"]
+        }
     },
 
     "extra": {


### PR DESCRIPTION
Builds on #1. Prefer stable over dev, remove bin, and use autoload-dev.
