### PR TITLE
Added the concept of Understands.

### DIFF
--- a/src/EventCentric/When/ConventionBased/ConventionBasedWhenUnderstands.php
+++ b/src/EventCentric/When/ConventionBased/ConventionBasedWhenUnderstands.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace EventCentric\When\ConventionBased;
+
+use EventCentric\DomainEvents\DomainEvent;
+use EventCentric\DomainEvents\DomainEvents;
+use EventCentric\When\Understands;
+use EventCentric\When\When;
+use Verraes\ClassFunctions\ClassFunctions;
+
+trait ConventionBasedWhenUnderstands
+{
+    use Understands;
+    use ConventionBasedWhen;
+
+    public function whenUnderstands(DomainEvent $domainEvent)
+    {
+        if ($this->understands($domainEvent)) {
+            $this->when($domainEvent);
+        }
+    }
+}

--- a/src/EventCentric/When/Understands.php
+++ b/src/EventCentric/When/Understands.php
@@ -20,8 +20,8 @@ trait Understands
             if ($domainEvent instanceof $type) {
                 return true;
             }
-
-            return false;
         }
+
+        return false;
     }
 }

--- a/src/EventCentric/When/Understands.php
+++ b/src/EventCentric/When/Understands.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace EventCentric\When;
+
+use EventCentric\DomainEvents\DomainEvent;
+use EventCentric\DomainEvents\DomainEvents;
+
+trait Understands
+{
+    abstract protected function understoodDomainEvents();
+
+    protected function understands(DomainEvent $domainEvent)
+    {
+        return $this->understandsAnyOf($domainEvent, $this->understoodDomainEvents());
+    }
+
+    protected function understandsAnyOf(DomainEvent $domainEvent, $types)
+    {
+        foreach ($types as $type) {
+            if ($domainEvent instanceof $type) {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/tests/EventCentric/When/Tests/ConventionBased/ConventionBasedWhenUnderstandsTest.php
+++ b/tests/EventCentric/When/Tests/ConventionBased/ConventionBasedWhenUnderstandsTest.php
@@ -26,8 +26,8 @@ final class MyReactorUnderstands
     public function test()
     {
         $domainEvents = new DomainEventsArray([
-            new SomethingWeUnderstandHappened(),
             new SomethingElseWeDoNotUnderstandHappened(),
+            new SomethingWeUnderstandHappened(),
         ]);
 
         foreach ($domainEvents as $domainEvent) {
@@ -45,7 +45,8 @@ final class MyReactorUnderstands
     protected function understoodDomainEvents()
     {
         return [
-            'EventCentric\When\Tests\ConventionBased\SomethingWeUnderstandHappened'
+            'EventCentric\When\Tests\ConventionBased\SomethingWeUnderstandButDoNotTouchHappened',
+            'EventCentric\When\Tests\ConventionBased\SomethingWeUnderstandHappened',
         ];
     }
 }

--- a/tests/EventCentric/When/Tests/ConventionBased/ConventionBasedWhenUnderstandsTest.php
+++ b/tests/EventCentric/When/Tests/ConventionBased/ConventionBasedWhenUnderstandsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace EventCentric\When\Tests\ConventionBased;
+
+use EventCentric\DomainEvents\DomainEvent;
+use EventCentric\DomainEvents\Implementations\DomainEventsArray;
+use EventCentric\When\ConventionBased\ConventionBasedWhenUnderstands;
+
+final class MyReactorUnderstands
+{
+    use ConventionBasedWhenUnderstands;
+
+    private $reacted = false;
+    private $overreacted = false;
+
+    protected function whenSomethingWeUnderstandHappened(SomethingWeUnderstandHappened $event)
+    {
+        $this->reacted = true;
+    }
+
+    protected function whenSomethingElseWeDoNotUnderstandHappened(SomethingElseWeDoNotUnderstandHappened $event)
+    {
+        $this->overreacted = true;
+    }
+
+    public function test()
+    {
+        $domainEvents = new DomainEventsArray([
+            new SomethingWeUnderstandHappened(),
+            new SomethingElseWeDoNotUnderstandHappened(),
+        ]);
+
+        foreach ($domainEvents as $domainEvent) {
+            $this->whenUnderstands($domainEvent);
+        }
+
+        if(!$this->reacted) {
+            throw new \Exception("The method 'whenSomethingWeUnderstandHappened' was not called");
+        }
+        if($this->overreacted) {
+            throw new \Exception("The method 'whenSomethingElseWeDoNotUnderstandHappened' was called and should not have been");
+        }
+    }
+
+    protected function understoodDomainEvents()
+    {
+        return [
+            'EventCentric\When\Tests\ConventionBased\SomethingWeUnderstandHappened'
+        ];
+    }
+}
+
+final class SomethingWeUnderstandHappened implements DomainEvent
+{}
+
+final class SomethingElseWeDoNotUnderstandHappened implements DomainEvent
+{}
+
+$reactor = new MyReactorUnderstands();
+$reactor->test();

--- a/tests/test.php
+++ b/tests/test.php
@@ -4,3 +4,4 @@ require_once __DIR__.'/../vendor/autoload.php';
 
 echo "Testing...\n";
 include __DIR__.'/EventCentric/When/Tests/ConventionBased/ConventionBasedWhenTest.php';
+include __DIR__.'/EventCentric/When/Tests/ConventionBased/ConventionBasedWhenUnderstandsTest.php';


### PR DESCRIPTION
I'm not exactly sure the best way to integrate this concept. The vanilla convention based when is really nice. This is useful in some cases, though, like with the other project I was working on. The "when" and "understands" seems like things that are nice and go together well but not mashed up for everyone to always have to use?

I tried putting the understands stuff directly in the convention based when and it felt weird. We could explore that more, though.

As-is, I left the understands stuff as its own trait that can be used and I created the convention based "where understands" that sews together the standalone "where" and "understands" concepts with a single "whereUnderstands" method. I thought this was pretty nice.

One thing I didn't like was the understoodDomainEvents method. I really wanted this to be static but the trait wouldn't let me have a static method call. :-/ If you know a way around this we can try to fix that somehow.
